### PR TITLE
Avoid "null" character

### DIFF
--- a/chapter4/java-net/src/main/java/ejm/chapter4/javanetclient/MessageResource.java
+++ b/chapter4/java-net/src/main/java/ejm/chapter4/javanetclient/MessageResource.java
@@ -40,13 +40,13 @@ public class MessageResource {
 
             BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
             String output;
-            String time = null;
+            String time = "";
 
             while ((output = reader.readLine()) != null) {
                 time += output;
             }
 
-            if (time != null) {
+            if (!time.isEmpty()) {
                 return message(this.timeUrl, time);
             } else {
                 return "Time service unavailable at " + this.timeUrl;
@@ -76,13 +76,13 @@ public class MessageResource {
 
                 BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
                 String output;
-                String time = null;
+                String time = "";
 
                 while ((output = reader.readLine()) != null) {
                     time += output;
                 }
 
-                if (time != null) {
+                if (!time.isEmpty()) {
                     asyncResponse.resume(message(this.timeUrl, time));
                 } else {
                     asyncResponse.resume("Time service unavailable at " + this.timeUrl);


### PR DESCRIPTION
The variable `time`  has "null" as String like the following because it is initialized with null and concatenated with time resource response.

``` console
$ curl localhost:8080/sync
The date and time at http://localhost:8081/ is nullMon, 3 Jul 2017 23:43:59 +0900
                                               ^^^^
```